### PR TITLE
additional BoostBinary wildcards for case-insensitive filesystem

### DIFF
--- a/src/utUtil/GlobFiles.cpp
+++ b/src/utUtil/GlobFiles.cpp
@@ -98,7 +98,7 @@ void globFiles( const std::string& directory, const enum FilePattern pattern, st
 		else if ( pattern == PATTERN_UBITRACK_CALIBRATION_FILES )
 			patternString = ".*\\.(cal)";
 		else if (pattern == PATTERN_UBITRACK_BOOST_BINARY)
-			patternString = ".*\\.(BoostBinary)";
+			patternString = ".*\\.(BoostBinary|boostbinary|BOOSTBINARY)";
 		globFiles ( directory, patternString, files, false);
 	}
 }


### PR DESCRIPTION
For windows, the BoostBinary-Glob will not return any files without this change. Please merge if someone else tries to use the frameplayer-.dfg's under windows.